### PR TITLE
Add inputs for some config items

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ jobs:
 
 Workflows completed using the `secrets.GITHUB_TOKEN` will not trigger other workflow actions, hence the use of `secrets.CI_TOKEN_*`. Two tokens are required as a user cannot approve their own pull request.
 
+### Inputs
+
+| Name           | Description                                                            | Required | Default                              |
+| -------------- | ---------------------------------------------------------------------- | -------- | ------------------------------------ |
+| github-token   | A GitHub token to complete the required actions                        | true     | -                                    |
+| pr-author      | The author of version bump PRs                                         | false    | guardian-ci                          |
+| pr-prefix      | The prefix to add to version bump PRs                                  | false    | chore(release):                      |
+| release-branch | The branch which releases are run from                                 | false    | main                                 |
+| branch-prefix  | The prefix to add to the branch name to commit version bump changes to | false    | release-                             |
+| commit-user    | The username of the user to commit version bump changes with           | false    | guardian-ci                          |
+| commit-email   | The email of the user to commit version bump changes with              | false    | guardian-ci@users.noreply.github.com |
+
 ## Development
 
 We follow the [script/task](https://github.com/github/scripts-to-rule-them-all) pattern, find useful scripts within the [script](https://github.com/guardian/post-release-action/blob/main/script) directory for common tasks.

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,30 @@ inputs:
   github-token:
     required: true
     description: A GitHub token
+  pr-author:
+    description: The author of version bump PRs
+    required: false
+    default: guardian-ci
+  pr-prefix:
+    description: The prefix to add to version bump PRs
+    required: false
+    default: 'chore(release):'
+  release-branch:
+    description: The branch which releases are run from
+    required: false
+    default: main
+  branch-prefix:
+    description: The prefix to add to the branch name to commit version bump changes to
+    required: false
+    default: release-
+  commit-user:
+    description: The username of the user to commit version bump changes with
+    required: false
+    default: guardian-ci
+  commit-email:
+    description: The email of the user to commit version bump changes with
+    required: false
+    default: guardian-ci@users.noreply.github.com
 branding:
   icon: 'package'
   color: 'gray-dark'

--- a/dist/index.js
+++ b/dist/index.js
@@ -2,7 +2,7 @@ module.exports =
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 351:
+/***/ 7351:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -15,8 +15,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os = __importStar(__nccwpck_require__(87));
-const utils_1 = __nccwpck_require__(278);
+const os = __importStar(__nccwpck_require__(2087));
+const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
  *
@@ -88,7 +88,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 186:
+/***/ 2186:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -110,11 +110,11 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const command_1 = __nccwpck_require__(351);
+const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
-const utils_1 = __nccwpck_require__(278);
-const os = __importStar(__nccwpck_require__(87));
-const path = __importStar(__nccwpck_require__(622));
+const utils_1 = __nccwpck_require__(5278);
+const os = __importStar(__nccwpck_require__(2087));
+const path = __importStar(__nccwpck_require__(5622));
 /**
  * The code to exit an action
  */
@@ -349,9 +349,9 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__nccwpck_require__(747));
-const os = __importStar(__nccwpck_require__(87));
-const utils_1 = __nccwpck_require__(278);
+const fs = __importStar(__nccwpck_require__(5747));
+const os = __importStar(__nccwpck_require__(2087));
+const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -369,7 +369,7 @@ exports.issueCommand = issueCommand;
 
 /***/ }),
 
-/***/ 278:
+/***/ 5278:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -395,7 +395,7 @@ exports.toCommandValue = toCommandValue;
 
 /***/ }),
 
-/***/ 514:
+/***/ 1514:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -417,7 +417,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tr = __importStar(__nccwpck_require__(159));
+const tr = __importStar(__nccwpck_require__(8159));
 /**
  * Exec a command.
  * Output will be streamed to the live console.
@@ -446,7 +446,7 @@ exports.exec = exec;
 
 /***/ }),
 
-/***/ 159:
+/***/ 8159:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -468,12 +468,12 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os = __importStar(__nccwpck_require__(87));
-const events = __importStar(__nccwpck_require__(614));
-const child = __importStar(__nccwpck_require__(129));
-const path = __importStar(__nccwpck_require__(622));
-const io = __importStar(__nccwpck_require__(436));
-const ioUtil = __importStar(__nccwpck_require__(962));
+const os = __importStar(__nccwpck_require__(2087));
+const events = __importStar(__nccwpck_require__(8614));
+const child = __importStar(__nccwpck_require__(3129));
+const path = __importStar(__nccwpck_require__(5622));
+const io = __importStar(__nccwpck_require__(7436));
+const ioUtil = __importStar(__nccwpck_require__(1962));
 /* eslint-disable @typescript-eslint/unbound-method */
 const IS_WINDOWS = process.platform === 'win32';
 /*
@@ -1053,15 +1053,15 @@ class ExecState extends events.EventEmitter {
 
 /***/ }),
 
-/***/ 53:
+/***/ 4087:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Context = void 0;
-const fs_1 = __nccwpck_require__(747);
-const os_1 = __nccwpck_require__(87);
+const fs_1 = __nccwpck_require__(5747);
+const os_1 = __nccwpck_require__(2087);
 class Context {
     /**
      * Hydrate the context from the environment
@@ -1110,7 +1110,7 @@ exports.Context = Context;
 
 /***/ }),
 
-/***/ 438:
+/***/ 5438:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1136,8 +1136,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOctokit = exports.context = void 0;
-const Context = __importStar(__nccwpck_require__(53));
-const utils_1 = __nccwpck_require__(30);
+const Context = __importStar(__nccwpck_require__(4087));
+const utils_1 = __nccwpck_require__(3030);
 exports.context = new Context.Context();
 /**
  * Returns a hydrated octokit ready to use for GitHub Actions
@@ -1153,7 +1153,7 @@ exports.getOctokit = getOctokit;
 
 /***/ }),
 
-/***/ 914:
+/***/ 7914:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1179,7 +1179,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getApiBaseUrl = exports.getProxyAgent = exports.getAuthString = void 0;
-const httpClient = __importStar(__nccwpck_require__(925));
+const httpClient = __importStar(__nccwpck_require__(9925));
 function getAuthString(token, options) {
     if (!token && !options.auth) {
         throw new Error('Parameter token or opts.auth is required');
@@ -1203,7 +1203,7 @@ exports.getApiBaseUrl = getApiBaseUrl;
 
 /***/ }),
 
-/***/ 30:
+/***/ 3030:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1229,12 +1229,12 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOctokitOptions = exports.GitHub = exports.context = void 0;
-const Context = __importStar(__nccwpck_require__(53));
-const Utils = __importStar(__nccwpck_require__(914));
+const Context = __importStar(__nccwpck_require__(4087));
+const Utils = __importStar(__nccwpck_require__(7914));
 // octokit + plugins
-const core_1 = __nccwpck_require__(762);
-const plugin_rest_endpoint_methods_1 = __nccwpck_require__(44);
-const plugin_paginate_rest_1 = __nccwpck_require__(193);
+const core_1 = __nccwpck_require__(6762);
+const plugin_rest_endpoint_methods_1 = __nccwpck_require__(3044);
+const plugin_paginate_rest_1 = __nccwpck_require__(4193);
 exports.context = new Context.Context();
 const baseUrl = Utils.getApiBaseUrl();
 const defaults = {
@@ -1264,15 +1264,15 @@ exports.getOctokitOptions = getOctokitOptions;
 
 /***/ }),
 
-/***/ 925:
+/***/ 9925:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const http = __nccwpck_require__(605);
-const https = __nccwpck_require__(211);
-const pm = __nccwpck_require__(443);
+const http = __nccwpck_require__(8605);
+const https = __nccwpck_require__(7211);
+const pm = __nccwpck_require__(6443);
 let tunnel;
 var HttpCodes;
 (function (HttpCodes) {
@@ -1691,7 +1691,7 @@ class HttpClient {
         if (useProxy) {
             // If using proxy, need tunnel
             if (!tunnel) {
-                tunnel = __nccwpck_require__(294);
+                tunnel = __nccwpck_require__(4294);
             }
             const agentOptions = {
                 maxSockets: maxSockets,
@@ -1807,7 +1807,7 @@ exports.HttpClient = HttpClient;
 
 /***/ }),
 
-/***/ 443:
+/***/ 6443:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -1872,7 +1872,7 @@ exports.checkBypass = checkBypass;
 
 /***/ }),
 
-/***/ 962:
+/***/ 1962:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1888,9 +1888,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 var _a;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const assert_1 = __nccwpck_require__(357);
-const fs = __nccwpck_require__(747);
-const path = __nccwpck_require__(622);
+const assert_1 = __nccwpck_require__(2357);
+const fs = __nccwpck_require__(5747);
+const path = __nccwpck_require__(5622);
 _a = fs.promises, exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
 exports.IS_WINDOWS = process.platform === 'win32';
 function exists(fsPath) {
@@ -2074,7 +2074,7 @@ function isUnixExecutable(stats) {
 
 /***/ }),
 
-/***/ 436:
+/***/ 7436:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -2089,10 +2089,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const childProcess = __nccwpck_require__(129);
-const path = __nccwpck_require__(622);
-const util_1 = __nccwpck_require__(669);
-const ioUtil = __nccwpck_require__(962);
+const childProcess = __nccwpck_require__(3129);
+const path = __nccwpck_require__(5622);
+const util_1 = __nccwpck_require__(1669);
+const ioUtil = __nccwpck_require__(1962);
 const exec = util_1.promisify(childProcess.exec);
 /**
  * Copies a file or folder.
@@ -2428,7 +2428,7 @@ exports.createTokenAuth = createTokenAuth;
 
 /***/ }),
 
-/***/ 762:
+/***/ 6762:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2436,10 +2436,10 @@ exports.createTokenAuth = createTokenAuth;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var universalUserAgent = __nccwpck_require__(429);
-var beforeAfterHook = __nccwpck_require__(682);
-var request = __nccwpck_require__(234);
-var graphql = __nccwpck_require__(668);
+var universalUserAgent = __nccwpck_require__(5030);
+var beforeAfterHook = __nccwpck_require__(3682);
+var request = __nccwpck_require__(6234);
+var graphql = __nccwpck_require__(8467);
 var authToken = __nccwpck_require__(334);
 
 function _objectWithoutPropertiesLoose(source, excluded) {
@@ -2610,7 +2610,7 @@ exports.Octokit = Octokit;
 
 /***/ }),
 
-/***/ 440:
+/***/ 9440:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -2618,8 +2618,8 @@ exports.Octokit = Octokit;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var isPlainObject = __nccwpck_require__(287);
-var universalUserAgent = __nccwpck_require__(429);
+var isPlainObject = __nccwpck_require__(3287);
+var universalUserAgent = __nccwpck_require__(5030);
 
 function lowercaseKeys(object) {
   if (!object) {
@@ -3008,7 +3008,7 @@ exports.endpoint = endpoint;
 
 /***/ }),
 
-/***/ 668:
+/***/ 8467:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -3016,8 +3016,8 @@ exports.endpoint = endpoint;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var request = __nccwpck_require__(234);
-var universalUserAgent = __nccwpck_require__(429);
+var request = __nccwpck_require__(6234);
+var universalUserAgent = __nccwpck_require__(5030);
 
 const VERSION = "4.6.0";
 
@@ -3124,7 +3124,7 @@ exports.withCustomRequest = withCustomRequest;
 
 /***/ }),
 
-/***/ 193:
+/***/ 4193:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -3264,7 +3264,7 @@ exports.paginateRest = paginateRest;
 
 /***/ }),
 
-/***/ 44:
+/***/ 3044:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -4428,8 +4428,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var deprecation = __nccwpck_require__(932);
-var once = _interopDefault(__nccwpck_require__(223));
+var deprecation = __nccwpck_require__(8932);
+var once = _interopDefault(__nccwpck_require__(1223));
 
 const logOnce = once(deprecation => console.warn(deprecation));
 /**
@@ -4481,7 +4481,7 @@ exports.RequestError = RequestError;
 
 /***/ }),
 
-/***/ 234:
+/***/ 6234:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -4491,9 +4491,9 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var endpoint = __nccwpck_require__(440);
-var universalUserAgent = __nccwpck_require__(429);
-var isPlainObject = __nccwpck_require__(287);
+var endpoint = __nccwpck_require__(9440);
+var universalUserAgent = __nccwpck_require__(5030);
+var isPlainObject = __nccwpck_require__(3287);
 var nodeFetch = _interopDefault(__nccwpck_require__(467));
 var requestError = __nccwpck_require__(537);
 
@@ -4637,12 +4637,12 @@ exports.request = request;
 
 /***/ }),
 
-/***/ 682:
+/***/ 3682:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var register = __nccwpck_require__(670)
-var addHook = __nccwpck_require__(549)
-var removeHook = __nccwpck_require__(819)
+var register = __nccwpck_require__(4670)
+var addHook = __nccwpck_require__(5549)
+var removeHook = __nccwpck_require__(6819)
 
 // bind with array of arguments: https://stackoverflow.com/a/21792913
 var bind = Function.bind
@@ -4701,7 +4701,7 @@ module.exports.Collection = Hook.Collection
 
 /***/ }),
 
-/***/ 549:
+/***/ 5549:
 /***/ ((module) => {
 
 module.exports = addHook;
@@ -4754,7 +4754,7 @@ function addHook(state, kind, name, hook) {
 
 /***/ }),
 
-/***/ 670:
+/***/ 4670:
 /***/ ((module) => {
 
 module.exports = register;
@@ -4788,7 +4788,7 @@ function register(state, name, method, options) {
 
 /***/ }),
 
-/***/ 819:
+/***/ 6819:
 /***/ ((module) => {
 
 module.exports = removeHook;
@@ -4814,7 +4814,7 @@ function removeHook(state, name, method) {
 
 /***/ }),
 
-/***/ 932:
+/***/ 8932:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -4842,7 +4842,7 @@ exports.Deprecation = Deprecation;
 
 /***/ }),
 
-/***/ 287:
+/***/ 3287:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -4898,11 +4898,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var Stream = _interopDefault(__nccwpck_require__(413));
-var http = _interopDefault(__nccwpck_require__(605));
-var Url = _interopDefault(__nccwpck_require__(835));
-var https = _interopDefault(__nccwpck_require__(211));
-var zlib = _interopDefault(__nccwpck_require__(761));
+var Stream = _interopDefault(__nccwpck_require__(2413));
+var http = _interopDefault(__nccwpck_require__(8605));
+var Url = _interopDefault(__nccwpck_require__(8835));
+var https = _interopDefault(__nccwpck_require__(7211));
+var zlib = _interopDefault(__nccwpck_require__(8761));
 
 // Based on https://github.com/tmpvar/jsdom/blob/aa85b2abf07766ff7bf5c1f6daafb3726f2f2db5/lib/jsdom/living/blob.js
 
@@ -5053,7 +5053,7 @@ FetchError.prototype.name = 'FetchError';
 
 let convert;
 try {
-	convert = __nccwpck_require__(877).convert;
+	convert = __nccwpck_require__(2877).convert;
 } catch (e) {}
 
 const INTERNALS = Symbol('Body internals');
@@ -6545,10 +6545,10 @@ exports.FetchError = FetchError;
 
 /***/ }),
 
-/***/ 223:
+/***/ 1223:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var wrappy = __nccwpck_require__(940)
+var wrappy = __nccwpck_require__(2940)
 module.exports = wrappy(once)
 module.exports.strict = wrappy(onceStrict)
 
@@ -6594,27 +6594,27 @@ function onceStrict (fn) {
 
 /***/ }),
 
-/***/ 294:
+/***/ 4294:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(219);
+module.exports = __nccwpck_require__(4219);
 
 
 /***/ }),
 
-/***/ 219:
+/***/ 4219:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 
-var net = __nccwpck_require__(631);
-var tls = __nccwpck_require__(16);
-var http = __nccwpck_require__(605);
-var https = __nccwpck_require__(211);
-var events = __nccwpck_require__(614);
-var assert = __nccwpck_require__(357);
-var util = __nccwpck_require__(669);
+var net = __nccwpck_require__(1631);
+var tls = __nccwpck_require__(4016);
+var http = __nccwpck_require__(8605);
+var https = __nccwpck_require__(7211);
+var events = __nccwpck_require__(8614);
+var assert = __nccwpck_require__(2357);
+var util = __nccwpck_require__(1669);
 
 
 exports.httpOverHttp = httpOverHttp;
@@ -6874,7 +6874,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 429:
+/***/ 5030:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -6900,7 +6900,7 @@ exports.getUserAgent = getUserAgent;
 
 /***/ }),
 
-/***/ 940:
+/***/ 2940:
 /***/ ((module) => {
 
 // Returns a wrapper function that returns a wrapped callback
@@ -6940,7 +6940,57 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
-/***/ 144:
+/***/ 6373:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getConfig = void 0;
+const core = __importStar(__nccwpck_require__(2186));
+const getConfigValue = (key, d) => {
+    const input = core.getInput(key);
+    return input && input !== '' ? input : d;
+};
+const getConfig = () => {
+    return {
+        maxFilesChanged: 2,
+        maxFileChanges: 2,
+        allowedFiles: ['package.json', 'package-lock.json', 'yarn.lock'],
+        expectedChanges: ['-  "version": "', '+  "version": "'],
+        pullRequestAuthor: getConfigValue('pr-author', 'jamie-lynch'),
+        pullRequestPrefix: getConfigValue('pr-prefix', 'chore(release):'),
+        releaseBranch: getConfigValue('release-branch', 'main'),
+        newBranchPrefix: getConfigValue('branch-prefix', 'release-'),
+        commitUser: getConfigValue('commit-user', 'guardian-ci'),
+        commitEmail: getConfigValue('commit-email', 'guardian-ci@users.noreply.github.com'),
+    };
+};
+exports.getConfig = getConfig;
+
+
+/***/ }),
+
+/***/ 6144:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -6974,38 +7024,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const core = __importStar(__nccwpck_require__(186));
-const exec_1 = __nccwpck_require__(514);
-const github = __importStar(__nccwpck_require__(438));
-const config = {
-    pullRequestAuthor: 'jamie-lynch',
-    pullRequestPrefix: 'chore(release):',
-    maxFilesChanged: 2,
-    maxFileChanges: 2,
-    allowedFiles: ['package.json', 'package-lock.json', 'yarn.lock'],
-    expectedChanges: ['-  "version": "', '+  "version": "'],
-    releaseBranch: 'main',
-    prTitlePrefix: 'chore(release): ',
-    newBranchPrefix: 'release-',
-    commitUser: 'guardian-ci',
-    commitEmail: 'guardian-ci@users.noreply.github.com',
-};
-/**
- * Decide what to do depending on the payload received
- *
- * For pushes to main, run preflight checks and then, if successful, release the
- * library to npm and open a new PR to bump the version in the package.json
- *
- * For pull requests, check if the PR matches the pattern for a version bump.
- * If it does then validate the PR to make sure it meets the requirements and,
- * if it does, approve it
- * Check that the PR is mergeable and, if it is, merge it
- *
- * @param object payload
- *
- * @throws Throws an error if the payload does not match any known conditions or if the underlying action throws an error
- */
-const decideAndTriggerAction = () => {
+const core = __importStar(__nccwpck_require__(2186));
+const exec_1 = __nccwpck_require__(1514);
+const github = __importStar(__nccwpck_require__(5438));
+const config_1 = __nccwpck_require__(6373);
+const decideAndTriggerAction = (config) => {
     var _a;
     const eventName = github.context.eventName;
     const payload = github.context.payload;
@@ -7013,14 +7036,14 @@ const decideAndTriggerAction = () => {
     core.debug(`Action type: ${(_a = payload.action) !== null && _a !== void 0 ? _a : 'Unknown'}`);
     switch (eventName) {
         case 'push':
-            return checkAndReleaseLibrary(payload);
+            return checkAndPRChanges(payload, config);
         case 'pull_request':
-            return checkApproveAndMergePR(payload);
+            return checkApproveAndMergePR(payload, config);
         default:
             throw new Error(`Unknown eventName: ${eventName}`);
     }
 };
-const checkApproveAndMergePR = (payload) => __awaiter(void 0, void 0, void 0, function* () {
+const checkApproveAndMergePR = (payload, config) => __awaiter(void 0, void 0, void 0, function* () {
     core.debug('checkApproveAndMergePR');
     core.debug(`Pull request: ${payload.pull_request.number}`);
     const prData = {
@@ -7028,7 +7051,7 @@ const checkApproveAndMergePR = (payload) => __awaiter(void 0, void 0, void 0, fu
         repo: payload.repository.name,
         pull_number: payload.pull_request.number,
     };
-    const token = core.getInput('github-token');
+    const token = core.getInput('github-token', { required: true });
     const octokit = github.getOctokit(token);
     // PR information isn't necessarily up to date in webhook payload
     // Get PR from the API to be sure
@@ -7072,20 +7095,9 @@ const checkApproveAndMergePR = (payload) => __awaiter(void 0, void 0, void 0, fu
     core.info(`PR mergeable. Merging`);
     yield octokit.pulls.merge(prData);
 });
-/**
- * Run any preflight checks, release the library to npm and open a PR to bump the version in the package.json
- *
- * Checks:
- * 1. The branch ${config.releaseBranch}
- * 2. There is a diff
- *
- * @param object payload
- *
- * @throws Throws an error if any of the preflight checks or the release process fail
- */
-const checkAndReleaseLibrary = (payload) => __awaiter(void 0, void 0, void 0, function* () {
+const checkAndPRChanges = (payload, config) => __awaiter(void 0, void 0, void 0, function* () {
     core.debug('checkAndReleaseLibrary');
-    const token = core.getInput('github-token');
+    const token = core.getInput('github-token', { required: true });
     if (payload.ref !== `refs/heads/${config.releaseBranch}`) {
         core.info(`Push is not to ${config.releaseBranch}, ignoring`);
         return;
@@ -7113,7 +7125,7 @@ const checkAndReleaseLibrary = (payload) => __awaiter(void 0, void 0, void 0, fu
         throw new Error('Could not find version number');
     }
     core.startGroup('Commiting changes');
-    const message = `${config.prTitlePrefix}${newVersion}`;
+    const message = `${config.pullRequestPrefix}${newVersion}`;
     const newBranch = `${config.newBranchPrefix}${newVersion}`;
     yield exec_1.exec(`git config --global user.email "${config.commitEmail}"`);
     yield exec_1.exec(`git config --global user.name "${config.commitUser}"`);
@@ -7140,7 +7152,8 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             core.info('Running @guardian/post-release-action');
-            yield decideAndTriggerAction();
+            const config = config_1.getConfig();
+            yield decideAndTriggerAction(config);
         }
         catch (error) {
             if (error instanceof Error) {
@@ -7157,7 +7170,7 @@ void run();
 
 /***/ }),
 
-/***/ 877:
+/***/ 2877:
 /***/ ((module) => {
 
 module.exports = eval("require")("encoding");
@@ -7165,7 +7178,7 @@ module.exports = eval("require")("encoding");
 
 /***/ }),
 
-/***/ 357:
+/***/ 2357:
 /***/ ((module) => {
 
 "use strict";
@@ -7173,7 +7186,7 @@ module.exports = require("assert");;
 
 /***/ }),
 
-/***/ 129:
+/***/ 3129:
 /***/ ((module) => {
 
 "use strict";
@@ -7181,7 +7194,7 @@ module.exports = require("child_process");;
 
 /***/ }),
 
-/***/ 614:
+/***/ 8614:
 /***/ ((module) => {
 
 "use strict";
@@ -7189,7 +7202,7 @@ module.exports = require("events");;
 
 /***/ }),
 
-/***/ 747:
+/***/ 5747:
 /***/ ((module) => {
 
 "use strict";
@@ -7197,7 +7210,7 @@ module.exports = require("fs");;
 
 /***/ }),
 
-/***/ 605:
+/***/ 8605:
 /***/ ((module) => {
 
 "use strict";
@@ -7205,7 +7218,7 @@ module.exports = require("http");;
 
 /***/ }),
 
-/***/ 211:
+/***/ 7211:
 /***/ ((module) => {
 
 "use strict";
@@ -7213,7 +7226,7 @@ module.exports = require("https");;
 
 /***/ }),
 
-/***/ 631:
+/***/ 1631:
 /***/ ((module) => {
 
 "use strict";
@@ -7221,7 +7234,7 @@ module.exports = require("net");;
 
 /***/ }),
 
-/***/ 87:
+/***/ 2087:
 /***/ ((module) => {
 
 "use strict";
@@ -7229,7 +7242,7 @@ module.exports = require("os");;
 
 /***/ }),
 
-/***/ 622:
+/***/ 5622:
 /***/ ((module) => {
 
 "use strict";
@@ -7237,7 +7250,7 @@ module.exports = require("path");;
 
 /***/ }),
 
-/***/ 413:
+/***/ 2413:
 /***/ ((module) => {
 
 "use strict";
@@ -7245,7 +7258,7 @@ module.exports = require("stream");;
 
 /***/ }),
 
-/***/ 16:
+/***/ 4016:
 /***/ ((module) => {
 
 "use strict";
@@ -7253,7 +7266,7 @@ module.exports = require("tls");;
 
 /***/ }),
 
-/***/ 835:
+/***/ 8835:
 /***/ ((module) => {
 
 "use strict";
@@ -7261,7 +7274,7 @@ module.exports = require("url");;
 
 /***/ }),
 
-/***/ 669:
+/***/ 1669:
 /***/ ((module) => {
 
 "use strict";
@@ -7269,7 +7282,7 @@ module.exports = require("util");;
 
 /***/ }),
 
-/***/ 761:
+/***/ 8761:
 /***/ ((module) => {
 
 "use strict";
@@ -7315,6 +7328,6 @@ module.exports = require("zlib");;
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __nccwpck_require__(144);
+/******/ 	return __nccwpck_require__(6144);
 /******/ })()
 ;

--- a/dist/index.js
+++ b/dist/index.js
@@ -6977,7 +6977,7 @@ const getConfig = () => {
         maxFileChanges: 2,
         allowedFiles: ['package.json', 'package-lock.json', 'yarn.lock'],
         expectedChanges: ['-  "version": "', '+  "version": "'],
-        pullRequestAuthor: getConfigValue('pr-author', 'jamie-lynch'),
+        pullRequestAuthor: getConfigValue('pr-author', 'guardian-ci'),
         pullRequestPrefix: getConfigValue('pr-prefix', 'chore(release):'),
         releaseBranch: getConfigValue('release-branch', 'main'),
         newBranchPrefix: getConfigValue('branch-prefix', 'release-'),

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,38 @@
+import * as core from '@actions/core';
+
+export interface Config {
+	pullRequestAuthor: string;
+	pullRequestPrefix: string;
+	maxFilesChanged: number;
+	maxFileChanges: number;
+	allowedFiles: string[];
+	expectedChanges: string[];
+	releaseBranch: string;
+	newBranchPrefix: string;
+	commitUser: string;
+	commitEmail: string;
+}
+
+const getConfigValue = (key: string, d: string) => {
+	const input = core.getInput(key);
+
+	return input && input !== '' ? input : d;
+};
+
+export const getConfig = (): Config => {
+	return {
+		maxFilesChanged: 2,
+		maxFileChanges: 2,
+		allowedFiles: ['package.json', 'package-lock.json', 'yarn.lock'],
+		expectedChanges: ['-  "version": "', '+  "version": "'],
+		pullRequestAuthor: getConfigValue('pr-author', 'jamie-lynch'), // 'guardian-ci',
+		pullRequestPrefix: getConfigValue('pr-prefix', 'chore(release):'),
+		releaseBranch: getConfigValue('release-branch', 'main'),
+		newBranchPrefix: getConfigValue('branch-prefix', 'release-'),
+		commitUser: getConfigValue('commit-user', 'guardian-ci'),
+		commitEmail: getConfigValue(
+			'commit-email',
+			'guardian-ci@users.noreply.github.com',
+		),
+	};
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,7 +25,7 @@ export const getConfig = (): Config => {
 		maxFileChanges: 2,
 		allowedFiles: ['package.json', 'package-lock.json', 'yarn.lock'],
 		expectedChanges: ['-  "version": "', '+  "version": "'],
-		pullRequestAuthor: getConfigValue('pr-author', 'jamie-lynch'), // 'guardian-ci',
+		pullRequestAuthor: getConfigValue('pr-author', 'guardian-ci'),
 		pullRequestPrefix: getConfigValue('pr-prefix', 'chore(release):'),
 		releaseBranch: getConfigValue('release-branch', 'main'),
 		newBranchPrefix: getConfigValue('branch-prefix', 'release-'),


### PR DESCRIPTION
## What does this change?

This PR refactors the config into a new file which exports an interface and a `getConfig` function. This function gets a number of user inputs and merges with the default config to produce the full config object. The `action.yml` file and  `README.md` are updated to detail the new inputs.

## How to test

Configure the action using inputs and see the resultant output.

## How can we measure success?

Options can be configured giving users more flexibility.