### PR TITLE
Get config depending on package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,15 +102,16 @@ Workflows completed using the `secrets.GITHUB_TOKEN` will not trigger other work
 
 ### Inputs
 
-| Name           | Description                                                            | Required | Default                              |
-| -------------- | ---------------------------------------------------------------------- | -------- | ------------------------------------ |
-| github-token   | A GitHub token to complete the required actions                        | true     | -                                    |
-| pr-author      | The author of version bump PRs                                         | false    | guardian-ci                          |
-| pr-prefix      | The prefix to add to version bump PRs                                  | false    | chore(release):                      |
-| release-branch | The branch which releases are run from                                 | false    | main                                 |
-| branch-prefix  | The prefix to add to the branch name to commit version bump changes to | false    | release-                             |
-| commit-user    | The username of the user to commit version bump changes with           | false    | guardian-ci                          |
-| commit-email   | The email of the user to commit version bump changes with              | false    | guardian-ci@users.noreply.github.com |
+| Name            | Description                                                            | Required | Default                              |
+| --------------- | ---------------------------------------------------------------------- | -------- | ------------------------------------ |
+| github-token    | A GitHub token to complete the required actions                        | true     | -                                    |
+| package-manager | The name of the package manager used: npm, yarn                        | false    | npm                                  |
+| pr-author       | The author of version bump PRs                                         | false    | guardian-ci                          |
+| pr-prefix       | The prefix to add to version bump PRs                                  | false    | chore(release):                      |
+| release-branch  | The branch which releases are run from                                 | false    | main                                 |
+| branch-prefix   | The prefix to add to the branch name to commit version bump changes to | false    | release-                             |
+| commit-user     | The username of the user to commit version bump changes with           | false    | guardian-ci                          |
+| commit-email    | The email of the user to commit version bump changes with              | false    | guardian-ci@users.noreply.github.com |
 
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,12 @@ runs:
   main: 'dist/index.js'
 inputs:
   github-token:
-    required: true
     description: A GitHub token
+    required: true
+  package-manager:
+    description: 'The name of the package manager used: npm, yarn'
+    required: false
+    default: npm
   pr-author:
     description: The author of version bump PRs
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -6967,23 +6967,34 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getConfig = void 0;
 const core = __importStar(__nccwpck_require__(2186));
+const packageManagerConfig = {
+    npm: {
+        maxFilesChanged: 2,
+        maxFileChanges: 2,
+        allowedFiles: ['package.json', 'package-lock.json'],
+        expectedChanges: ['-  "version": "', '+  "version": "'],
+    },
+    yarn: {
+        maxFilesChanged: 1,
+        maxFileChanges: 1,
+        allowedFiles: ['package.json'],
+        expectedChanges: ['-  "version": "', '+  "version": "'],
+    },
+};
+const allowedPackageManagerValues = Object.keys(packageManagerConfig);
 const getConfigValue = (key, d) => {
     const input = core.getInput(key);
     return input && input !== '' ? input : d;
 };
+const getPackageManagerConfig = () => {
+    const pm = getConfigValue('package-manager', 'npm');
+    if (!allowedPackageManagerValues.includes(pm)) {
+        throw new Error(`Invalid package-manager value (${pm}) provided. Allowed values are: ${allowedPackageManagerValues.join(', ')}`);
+    }
+    return packageManagerConfig[pm];
+};
 const getConfig = () => {
-    return {
-        maxFilesChanged: 2,
-        maxFileChanges: 2,
-        allowedFiles: ['package.json', 'package-lock.json', 'yarn.lock'],
-        expectedChanges: ['-  "version": "', '+  "version": "'],
-        pullRequestAuthor: getConfigValue('pr-author', 'guardian-ci'),
-        pullRequestPrefix: getConfigValue('pr-prefix', 'chore(release):'),
-        releaseBranch: getConfigValue('release-branch', 'main'),
-        newBranchPrefix: getConfigValue('branch-prefix', 'release-'),
-        commitUser: getConfigValue('commit-user', 'guardian-ci'),
-        commitEmail: getConfigValue('commit-email', 'guardian-ci@users.noreply.github.com'),
-    };
+    return Object.assign(Object.assign({}, getPackageManagerConfig()), { pullRequestAuthor: getConfigValue('pr-author', 'guardian-ci'), pullRequestPrefix: getConfigValue('pr-prefix', 'chore(release):'), releaseBranch: getConfigValue('release-branch', 'main'), newBranchPrefix: getConfigValue('branch-prefix', 'release-'), commitUser: getConfigValue('commit-user', 'guardian-ci'), commitEmail: getConfigValue('commit-email', 'guardian-ci@users.noreply.github.com') });
 };
 exports.getConfig = getConfig;
 


### PR DESCRIPTION
## What does this change?

The following config values are set depending on the `package-manager` input provided (which defaults to npm). 

- maxFilesChanged
- maxFileChanges
- allowedFiles
- expectedChanges

## How to test

Run the release process with `npm` and `yarn` and ensure it works as expected

## How can we measure success?

Checks are tailored to the package manager in use