### PR TITLE
Add space between PR prefix and value

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,16 +102,16 @@ Workflows completed using the `secrets.GITHUB_TOKEN` will not trigger other work
 
 ### Inputs
 
-| Name            | Description                                                            | Required | Default                              |
-| --------------- | ---------------------------------------------------------------------- | -------- | ------------------------------------ |
-| github-token    | A GitHub token to complete the required actions                        | true     | -                                    |
-| package-manager | The name of the package manager used: npm, yarn                        | false    | npm                                  |
-| pr-author       | The author of version bump PRs                                         | false    | guardian-ci                          |
-| pr-prefix       | The prefix to add to version bump PRs                                  | false    | chore(release):                      |
-| release-branch  | The branch which releases are run from                                 | false    | main                                 |
-| branch-prefix   | The prefix to add to the branch name to commit version bump changes to | false    | release-                             |
-| commit-user     | The username of the user to commit version bump changes with           | false    | guardian-ci                          |
-| commit-email    | The email of the user to commit version bump changes with              | false    | guardian-ci@users.noreply.github.com |
+| Name            | Description                                                                             | Required | Default                              |
+| --------------- | --------------------------------------------------------------------------------------- | -------- | ------------------------------------ |
+| github-token    | A GitHub token to complete the required actions                                         | true     | -                                    |
+| package-manager | The name of the package manager used: npm, yarn                                         | false    | npm                                  |
+| pr-author       | The author of version bump PRs                                                          | false    | guardian-ci                          |
+| pr-prefix       | The prefix to add to version bump PRs (note that a space will be added after the value) | false    | chore(release):                      |
+| release-branch  | The branch which releases are run from                                                  | false    | main                                 |
+| branch-prefix   | The prefix to add to the branch name to commit version bump changes to                  | false    | release-                             |
+| commit-user     | The username of the user to commit version bump changes with                            | false    | guardian-ci                          |
+| commit-email    | The email of the user to commit version bump changes with                               | false    | guardian-ci@users.noreply.github.com |
 
 ### Repository Settings
 

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: false
     default: guardian-ci
   pr-prefix:
-    description: The prefix to add to version bump PRs
+    description: The prefix to add to version bump PRs (note that a space will be added after the value)
     required: false
     default: 'chore(release):'
   release-branch:

--- a/dist/index.js
+++ b/dist/index.js
@@ -7136,7 +7136,7 @@ const checkAndPRChanges = (payload, config) => __awaiter(void 0, void 0, void 0,
         throw new Error('Could not find version number');
     }
     core.startGroup('Commiting changes');
-    const message = `${config.pullRequestPrefix}${newVersion}`;
+    const message = `${config.pullRequestPrefix} ${newVersion}`;
     const newBranch = `${config.newBranchPrefix}${newVersion}`;
     yield exec_1.exec(`git config --global user.email "${config.commitEmail}"`);
     yield exec_1.exec(`git config --global user.name "${config.commitUser}"`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,7 +160,7 @@ const checkAndPRChanges = async (payload: PushEvent, config: Config) => {
 
 	core.startGroup('Commiting changes');
 
-	const message = `${config.pullRequestPrefix}${newVersion}`;
+	const message = `${config.pullRequestPrefix} ${newVersion}`;
 	const newBranch = `${config.newBranchPrefix}${newVersion}`;
 
 	await exec(`git config --global user.email "${config.commitEmail}"`);


### PR DESCRIPTION
## What does this change?

This PR adds a space between the `pullRequestPrefix` and `newVersion` when constructing the commit message and PR title. This space is required as otherwise the PR title validation fails. As the `pullRequestPrefix` value can be provided via an input and GitHub trims input strings, this space must be coded into the application rather than relying on the `pullRequestPrefix` value to provide the trailing space. A note has been added to the `README` and `action.yml` file to warn the users of this behaviour.

## How to test

Run the release process and see that it works as expected

## How can we measure success?

The automated release process works E2E.
