### PR TITLE
chore(deps): Bump dependencies (11/10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1061,9 +1061,9 @@
       }
     },
     "@types/jest": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.1.tgz",
-      "integrity": "sha512-HTLpVXHrY69556ozYkcq47TtQJXpcWAWfkoqz+ZGz2JnmZhzlRjprCIyFnetSy8gpDWwTTGBcRVv1J1I1vBrHw==",
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.2.tgz",
+      "integrity": "sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==",
       "dev": true,
       "requires": {
         "jest-diff": "^27.0.0",
@@ -1071,9 +1071,9 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
-          "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
+          "version": "27.2.5",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
+          "integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1092,6 +1092,12 @@
             "@types/yargs-parser": "*"
           }
         },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -1105,15 +1111,15 @@
           "dev": true
         },
         "jest-diff": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.6.tgz",
-          "integrity": "sha512-Z1mqgkTCSYaFgwTlP/NUiRzdqgxmmhzHY1Tq17zL94morOHfHu3K4bgSgl+CR4GLhpV8VxkuOYuIWnQ9LnFqmg==",
+          "version": "27.2.5",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.2.5.tgz",
+          "integrity": "sha512-7gfwwyYkeslOOVQY4tVq5TaQa92mWfC9COsVYMNVYyJTOYAqbIkoD3twi5A+h+tAPtAelRxkqY6/xu+jwTr0dA==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
             "diff-sequences": "^27.0.6",
             "jest-get-type": "^27.0.6",
-            "pretty-format": "^27.0.6"
+            "pretty-format": "^27.2.5"
           }
         },
         "jest-get-type": {
@@ -1123,13 +1129,13 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "27.0.6",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
-          "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
+          "version": "27.2.5",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.5.tgz",
+          "integrity": "sha512-+nYn2z9GgicO9JiqmY25Xtq8SYfZ/5VCpEU3pppHHNAhd1y+ZXxmNPd1evmNcAd6Hz4iBV2kf0UpGth5A/VJ7g==",
           "dev": true,
           "requires": {
-            "@jest/types": "^27.0.6",
-            "ansi-regex": "^5.0.0",
+            "@jest/types": "^27.2.5",
+            "ansi-regex": "^5.0.1",
             "ansi-styles": "^5.0.0",
             "react-is": "^17.0.1"
           }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@guardian/prettier": "^0.7.0",
     "@octokit/types": "^6.34.0",
     "@octokit/webhooks-types": "^4.12.0",
-    "@types/jest": "^27.0.1",
+    "@types/jest": "^27.0.2",
     "@types/node": "^16.10.3",
     "@vercel/ncc": "^0.31.1",
     "eslint": "^7.32.0",


### PR DESCRIPTION
*  bump @octokit/types from 6.28.1 to 6.34.0 
* bump @octokit/webhooks-types from 4.7.0 to 4.12.0
* bump @types/node from 16.9.4 to 16.10.3
* bump type-fest from 2.3.3 to 2.3.4
* bump @types/jest from 27.0.1 to 27.0.2